### PR TITLE
Update to use the snap

### DIFF
--- a/broadcast/how-to-install-spotify-in-ubuntu.php
+++ b/broadcast/how-to-install-spotify-in-ubuntu.php
@@ -31,12 +31,12 @@ if ($Request['path'] === $Place['path'].$Canonical) {
 				<p>This is a preview build of Spotify for Linux. As a preview release this version is still unsupported, but we're running it ourselves and will try to make sure it keeps pace with its Mac and Windows siblings.</p>
 			</blockquote>
 			<p><a href="https://www.spotify.com/">Spotify</a> is a great way to listen to music by streaming it on your phone, in your browser, or on your Linux desktop. You can stream everything, upgrade and sync tracks and playlists offline, or purchase individual tracks to keep forever.</p>
-			<p>The following code will add the Spotify repository, authenticate it (which makes sure the software you install is the official one), checks for the latest version, and installs Spotify. You should copy and paste this code into your Terminal and execute it.</p>
-			<textarea class="textleft code resize">sudo apt-add-repository -y &quot;deb http://repository.spotify.com stable non-free&quot; &&
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2C19886 &&
-sudo apt-get update -qq &&
-sudo apt-get install spotify-client</textarea>
-			<p>You can view these commands individually at the <a href="http://www.spotify.com/uk/download/previews/">Official Spotify Linux Preview page</a>.</p>
+			<p>Since December 2017, the Spotify developers have maintained a snap of their music player. The snap can be installed on all supported releases back to 14.04.</p> 
+			<p>The following two lines will install the Spotify snap. Once installed, you'll get updates to the Spotify client as and when the developers upload it to the store. You should copy and paste this code into your Terminal and execute it.</p>
+			<textarea class="textleft code resize">
+sudo apt install snapd
+sudo snap install spotify</textarea>
+			<p>You can get support for this build of Spotify on their <a href="https://community.spotify.com/t5/Desktop-Linux/bd-p/desktop_linux">community support site</a>.</p>
 		</div>
 		<div class="col span_1_of_6"><br></div>
 	</div>


### PR DESCRIPTION
This PR will update the spotify installation instructions to use the newer snap, which works on all supported releases of Ubuntu.